### PR TITLE
Update Azure Container Registry image naming in CI workflow

### DIFF
--- a/.github/workflows/application.yml
+++ b/.github/workflows/application.yml
@@ -139,7 +139,7 @@ jobs:
         with:
           app-name: ${{ vars.WEBAPP }}
           slot-name: ${{ vars.DEPLOYMENT_SLOT }}
-          images: ${{ vars.CONTAINER_REGISTRY }}.azurecr.io/ondfisk-githubdemo:${{ env.IMAGE_TAG }}
+          images: ${{ vars.CONTAINER_REGISTRY }}.azurecr.io/githubdemo:${{ env.IMAGE_TAG }}
         env:
           IMAGE_TAG: ${{ github.ref == 'refs/heads/main' && 'latest' || 'test' }}
 

--- a/.github/workflows/application.yml
+++ b/.github/workflows/application.yml
@@ -73,9 +73,9 @@ jobs:
         if: github.ref == 'refs/heads/main' || github.event_name == 'pull_request'
         run: |
           az acr login --name ${{ vars.CONTAINER_REGISTRY }}
-          IMAGE="${{ vars.CONTAINER_REGISTRY }}.azurecr.io/ondfisk-githubdemo"
-          docker tag "ondfisk-githubdemo:${{ github.sha }}" "$IMAGE:${{ github.sha }}"
-          docker tag "ondfisk-githubdemo:${{ github.sha }}" "$IMAGE:${{ env.IMAGE_TAG }}"
+          IMAGE="${{ vars.CONTAINER_REGISTRY }}.azurecr.io/githubdemo"
+          docker tag "githubdemo:${{ github.sha }}" "$IMAGE:${{ github.sha }}"
+          docker tag "githubdemo:${{ github.sha }}" "$IMAGE:${{ env.IMAGE_TAG }}"
           docker push $IMAGE --all-tags
         env:
           IMAGE_TAG: ${{ github.ref == 'refs/heads/main' && 'latest' || 'test' }}


### PR DESCRIPTION
This pull request includes a change to the `.github/workflows/application.yml` file to update the image naming convention used in the Docker commands.

Changes to image naming convention:

* [`.github/workflows/application.yml`](diffhunk://#diff-dc5f32521b4ae99ff8632eb151f06cb36a62fe139292cbbf3f2a4afc79647581L76-R78): Updated the image name from `ondfisk-githubdemo` to `githubdemo` in the Docker tagging and pushing steps.